### PR TITLE
scope handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "scripts": {
+    "prepare": "npm run build",
     "build": "tsc --project tsconfig.json",
     "typecheck": "tsc --project tsconfig.json --noEmit",
     "lint": "eslint --ext .ts,.tsx src/",

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,14 +246,14 @@ export class DiscordStrategy<User> extends OAuth2Strategy<
       verify
     );
 
-    this.scope = scope ? scope : ["identify", "email"];
+    this.scope = (scope ? scope : ["identify", "email"]).join(" ");
 
     this.prompt = prompt;
   }
 
   protected authorizationParams() {
     const params = new URLSearchParams({
-      scope: this.scope.join(" "),
+      scope: this.scope,
     });
     if (this.prompt) params.set("prompt", this.prompt);
     return params;

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,7 +218,7 @@ export class DiscordStrategy<User> extends OAuth2Strategy<
 > {
   name = DiscordStrategyDefaultName;
 
-  private scope: Array<DiscordScope>;
+  private scope: string;
   private prompt?: "none" | "consent";
   private userInfoURL = `${discordApiBaseURL}/users/@me`;
 


### PR DESCRIPTION
remix-auth-oauth2 now provides scopes. and it would transform them leading to errors. this should fix it