### PR TITLE
Add integrationType parameter to DiscordStrategyOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,20 @@ export type DiscordScope =
   | "webhook.incoming";
 
 /**
+ * The integration_type parameter specifies the installation context for the authorization.
+ * The installation context determines where the application will be installed,
+ * and is only relevant when scope contains applications.commands.
+ * When set to 0 (GUILD_INSTALL) the application will be authorized for installation to a server,
+ * and when set to 1 (USER_INSTALL) the application will be authorized for installation to a user.
+ * The application must be configured in the Developer Portal to support the provided integration_type.
+ * @see https://discord.com/developers/docs/resources/application#application-object-application-integration-types
+ */
+export enum DiscordIntegrationType {
+  GUILD_INSTALL = 0,
+  USER_INSTALL = 1,
+}
+
+/**
  * These are all the available Guild Features
  * @see https://discord.com/developers/docs/resources/guild#guild-object-guild-features
  */
@@ -135,16 +149,7 @@ export interface DiscordStrategyOptions {
    * @default ["identify", "email"]
    */
   scope?: Array<DiscordScope>;
-  /**
-   * The integration_type parameter specifies the installation context for the authorization.
-   * The installation context determines where the application will be installed,
-   * and is only relevant when scope contains applications.commands.
-   * When set to 0 (GUILD_INSTALL) the application will be authorized for installation to a server,
-   * and when set to 1 (USER_INSTALL) the application will be authorized for installation to a user.
-   * The application must be configured in the Developer Portal to support the provided integration_type.
-   */
-  // if scope contains applications.commands, integration_type is required
-  integrationType?: 0 | 1;
+  integrationType?: DiscordIntegrationType;
   prompt?: "none" | "consent";
 }
 
@@ -248,7 +253,7 @@ export class DiscordStrategy<User> extends OAuth2Strategy<
   name = DiscordStrategyDefaultName;
 
   scope: string;
-  private integrationType: DiscordStrategyOptions["integrationType"];
+  private integrationType?: DiscordStrategyOptions["integrationType"];
   private prompt?: "none" | "consent";
   private userInfoURL = `${discordApiBaseURL}/users/@me`;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -283,10 +283,18 @@ export class DiscordStrategy<User> extends OAuth2Strategy<
     );
 
     this.scope = (scope ?? ["identify", "email"]).join(" ");
-    if (scope?.includes("applications.commands") && !integrationType)
+    if (
+      scope?.includes("applications.commands") &&
+      integrationType === undefined
+    )
       throw new Error(
         "integrationType is required when scope contains applications.commands",
       );
+    if (
+      integrationType &&
+      !Object.values(DiscordIntegrationType).includes(integrationType)
+    )
+      throw new Error("integrationType must be a valid DiscordIntegrationType");
     this.integrationType = integrationType;
     this.prompt = prompt;
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -102,6 +102,39 @@ describe(DiscordStrategy, () => {
     }
   });
 
+  test("should correctly set the integrationType", async () => {
+    const strategy = new DiscordStrategy(
+      {
+        clientID: "CLIENT_ID",
+        clientSecret: "CLIENT_SECRET",
+        callbackURL: "https://example.app/callback",
+        scope: ["email", "applications.commands", "identify"],
+        integrationType: 1,
+      },
+      verify,
+    );
+
+    const request = new Request("https://example.app/auth/discord");
+
+    try {
+      await strategy.authenticate(request, sessionStorage, {
+        sessionKey: "user",
+        sessionErrorKey: "auth:error",
+        sessionStrategyKey: "strategy",
+        name: "__session",
+      });
+    } catch (error) {
+      if (!(error instanceof Response)) throw error;
+      const location = error.headers.get("Location");
+
+      if (!location) throw new Error("No redirect header");
+
+      const redirectUrl = new URL(location);
+
+      expect(redirectUrl.searchParams.get("integration_type")).toBe("1");
+    }
+  });
+
   test("should correctly format the authorization URL", async () => {
     const strategy = new DiscordStrategy(
       {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -74,6 +74,34 @@ describe(DiscordStrategy, () => {
     }
   });
 
+  test("should require integrationType when scope `applications.commands` is added", async () => {
+    try {
+      const strategy = new DiscordStrategy(
+        {
+          clientID: "CLIENT_ID",
+          clientSecret: "CLIENT_SECRET",
+          callbackURL: "https://example.app/callback",
+          scope: ["email", "applications.commands", "identify"],
+        },
+        verify,
+      );
+
+      const request = new Request("https://example.app/auth/discord");
+
+      await strategy.authenticate(request, sessionStorage, {
+        sessionKey: "user",
+        sessionErrorKey: "auth:error",
+        sessionStrategyKey: "strategy",
+        name: "__session",
+      });
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe(
+        "integrationType is required when scope contains applications.commands",
+      );
+    }
+  });
+
   test("should correctly format the authorization URL", async () => {
     const strategy = new DiscordStrategy(
       {


### PR DESCRIPTION
This pull request adds the `integrationType` parameter to the `DiscordStrategyOptions` interface and the `DiscordStrategy` class.

The `integrationType` parameter specifies the installation context for the authorization and is only relevant when the `scope` contains `applications.commands`.

Also added tests to ensure that the `integrationType` is correctly set and that an error is thrown when it is required but not provided.